### PR TITLE
Update HttpPush.php to handle mix.version()

### DIFF
--- a/src/HttpPush.php
+++ b/src/HttpPush.php
@@ -69,7 +69,7 @@ class HttpPush
      */
     public static function getTypeByExtension(string $resourcePath) : string
     {
-        $parts = explode('.', $resourcePath);
+        $parts = explode('.', explode('?', $resourcePath)[0]);
         $extension = end($parts);
         switch ($extension) {
             case 'css': return 'style';


### PR DESCRIPTION
When using `mix.version()`, `getTypeByExtension()` does not take into account the query string on the url and improperly marks all versioned assets as `image`. To fix, split `$resourcePath` by `?` to give us a clean, non-versioned asset url, which we can then split by `.` to get the correct file extension.